### PR TITLE
OP가 플러그인 종료후 봇테러 날리는일 방지

### DIFF
--- a/src/main/java/cloud/swiftnode/kspam/KSpam.java
+++ b/src/main/java/cloud/swiftnode/kspam/KSpam.java
@@ -63,6 +63,9 @@ public class KSpam extends JavaPlugin {
     public void onDisable() {
         saveConfig();
         new CacheSaveProcessor().process();
+        //OP가 플러그인 종료후 봇테러 날리는일 방지
+        System.out.println("경고! K-SPAM 플러그인이 종료되었습니다. 서버와 함께 종료됩니다.");
+        Bukkit.shutdown();
     }
 
     @Override


### PR DESCRIPTION
서버 내 일부 부패한 관리자가 플러그인을 일부러 정지시키고 봇테러를 시전하는 케이스를 방지하기 위해 플러그인이 종료될경우 서버와 함께 종료되도록 설계하였습니다.